### PR TITLE
remove deprecated dropdownPosition prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
-    "@thirdweb-dev/react": "^4",
+    "@thirdweb-dev/react": "^4.4",
     "@thirdweb-dev/sdk": "^4",
     "ethers": "^5",
     "react": "^18.2",

--- a/src/App.js
+++ b/src/App.js
@@ -26,12 +26,7 @@ export default function Home() {
           </p>
 
           <div className="connect">
-            <ConnectWallet
-              dropdownPosition={{
-                side: "bottom",
-                align: "center",
-              }}
-            />
+            <ConnectWallet />
           </div>
         </div>
 


### PR DESCRIPTION
A [recent update](https://github.com/thirdweb-dev/js/commit/212b2e7bc28c8e88207a9935756f7e6133a5b7d3) to the ConnectWallet component removed the dropdownPosition prop. 


This update removes the reference to the deprecated dropdownPosition prop in the ConnectWallet component.